### PR TITLE
refactor: centralize shared RSI settings

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration package for shared constants."""

--- a/config/shared.py
+++ b/config/shared.py
@@ -1,0 +1,20 @@
+"""Global configuration shared by RSI scripts.
+
+This module holds constants that are reused across different
+interval scripts, such as RSI thresholds and notification endpoints.
+"""
+
+# RSI threshold settings used by both 1d and 4h scripts
+RSI_OVERBOUGHT_14 = 65
+RSI_OVERSOLD_14 = 35
+RSI_OVERBOUGHT_6 = 70
+RSI_OVERSOLD_6 = 30
+
+# Notification endpoints (e.g., Server酱 / PushDeer)
+NOTIFICATION_URLS = {
+    # 'server_chan': "https://sctapi.ftqq.com/XXX.send?title={}&desp={}",
+    'push_ft07': (
+        "https://sctp11310thhgz5tizmjdsetszjitcko.push.ft07.com/send/"
+        "sctp11310thhgz5tizmjdsetszjitcko.send?title={}&desp={}"
+    ),
+}

--- a/rsi1d.py
+++ b/rsi1d.py
@@ -1,3 +1,10 @@
+"""RSI 日线脚本
+
+Global thresholds and notification URLs are defined in
+``config.shared``. The settings below are specific to the daily
+interval such as API endpoints, delays and crypto mappings.
+"""
+
 import requests
 import pandas as pd
 import time
@@ -6,37 +13,35 @@ from typing import Dict, List, Tuple, Optional, Any
 import logging
 from datetime import datetime
 
+from config import shared
+
 # 配置日志
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-# 配置常量
 class Config:
-    # API配置
+    # API配置（日线特有）
     COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3"
     REQUEST_TIMEOUT = 30
     RETRY_ATTEMPTS = 3
-    
+
     # RSI配置
     DEFAULT_RSI_PERIODS = [14, 6]
     DEFAULT_DAYS = 30
-    
-    # 阈值配置
-    RSI_OVERBOUGHT_14 = 65
-    RSI_OVERSOLD_14 = 35
-    RSI_OVERBOUGHT_6 = 70
-    RSI_OVERSOLD_6 = 30
-    
-    # 通知配置
-    NOTIFICATION_URLS = {
-        # 'server_chan': "https://sctapi.ftqq.com/SCT241317TwvSKJKGGttpZcEe2j9CQgjDo.send?title={}&desp={}", # 微信接口，暂不推送
-        'push_ft07': "https://sctp11310thhgz5tizmjdsetszjitcko.push.ft07.com/send/sctp11310thhgz5tizmjdsetszjitcko.send?title={}&desp={}"
-    }
-    
-    # 延迟配置
+
+    # 阈值配置（全局）
+    RSI_OVERBOUGHT_14 = shared.RSI_OVERBOUGHT_14
+    RSI_OVERSOLD_14 = shared.RSI_OVERSOLD_14
+    RSI_OVERBOUGHT_6 = shared.RSI_OVERBOUGHT_6
+    RSI_OVERSOLD_6 = shared.RSI_OVERSOLD_6
+
+    # 通知配置（全局）
+    NOTIFICATION_URLS = shared.NOTIFICATION_URLS
+
+    # 延迟配置（日线特有）
     API_CALL_DELAY = 20  # 秒
 
-    # 加密货币配置
+    # 加密货币配置（日线特有）
     CRYPTO_IDS = {
         "BTC": "bitcoin",
         "ETH": "ethereum",

--- a/rsi4h.py
+++ b/rsi4h.py
@@ -20,28 +20,33 @@ from typing import Any, Dict, Tuple
 import pandas as pd
 import requests
 
+from config import shared
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
 class Config:
-    """Configuration for RSI-4h calculations and notifications."""
+    """Configuration for RSI-4h calculations.
 
+    Global RSI thresholds and notification URLs are defined in
+    :mod:`config.shared`; the values below are specific to the 4‑hour
+    interval.
+    """
+
+    # Interval-specific API settings
     BASE_URL = "https://min-api.cryptocompare.com/data/v2/histohour"
     API_KEY = os.getenv("CC_API_KEY")
     API_CALL_DELAY = 5
 
-    RSI_OVERBOUGHT_14 = 65
-    RSI_OVERSOLD_14 = 35
-    RSI_OVERBOUGHT_6 = 70
-    RSI_OVERSOLD_6 = 30
+    # Shared RSI thresholds
+    RSI_OVERBOUGHT_14 = shared.RSI_OVERBOUGHT_14
+    RSI_OVERSOLD_14 = shared.RSI_OVERSOLD_14
+    RSI_OVERBOUGHT_6 = shared.RSI_OVERBOUGHT_6
+    RSI_OVERSOLD_6 = shared.RSI_OVERSOLD_6
 
-    NOTIFICATION_URLS = {
-        "push_ft07": (
-            "https://sctp11310thhgz5tizmjdsetszjitcko.push.ft07.com/send/"
-            "sctp11310thhgz5tizmjdsetszjitcko.send?title={}&desp={}"
-        )
-    }
+    # Shared notification endpoints
+    NOTIFICATION_URLS = shared.NOTIFICATION_URLS
 
 
 def fetch_ohlcv(symbol: str, limit: int = 100) -> pd.Series:


### PR DESCRIPTION
## Summary
- extract global RSI thresholds and notification URLs into `config/shared.py`
- consume shared settings from `rsi1d.py` and `rsi4h.py`
- document which configs are global vs interval-specific

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c401b2418c83219ffbb1e94c849ca0