### PR TITLE
Add price tracking to RSI alerts

### DIFF
--- a/quick_test.py
+++ b/quick_test.py
@@ -5,7 +5,15 @@ if 'rsi1d' in sys.modules:
 
 from rsi1d import format_rsi_message
 
-test_data = {'BTC (RSI-14)': '超买: 72.50'}
+test_data = [
+    {
+        'symbol': 'BTC',
+        'indicator': 'RSI-14',
+        'signal': '超买',
+        'rsi_value': 72.50,
+        'price': 63123.45,
+    }
+]
 title, content = format_rsi_message(test_data)
 
 if '<font color=' in content:
@@ -13,4 +21,14 @@ if '<font color=' in content:
 else:
     print("✅ 已移除颜色标签")
 
-print("RSI值部分:", [line for line in content.split('\n') if 'BTC' in line][0] if any('BTC' in line for line in content.split('\n')) else "未找到")
+print(
+    "RSI值部分:",
+    [line for line in content.split('\n') if 'BTC' in line][0]
+    if any('BTC' in line for line in content.split('\n'))
+    else "未找到",
+)
+
+if '最新价格' in content and '$63,123.45' in content:
+    print("✅ 包含最新价格列")
+else:
+    print("❌ 未包含最新价格列")

--- a/rsi1d.py
+++ b/rsi1d.py
@@ -151,17 +151,20 @@ def calculate_crypto_rsi(crypto_ids: Dict[str, str]) -> Dict[str, Dict[str, Any]
                     'error': True
                 }
             else:
-                rsi_14 = rsi_14_series.iloc[-1]
-                rsi_6 = rsi_6_series.iloc[-1]
+                rsi_14 = float(rsi_14_series.iloc[-1])
+                rsi_6 = float(rsi_6_series.iloc[-1])
+                latest_price = float(prices.iloc[-1])
                 results[symbol] = {
                     'rsi_14': rsi_14,
                     'rsi_6': rsi_6,
+                    'price': latest_price,
                     'error': False
                 }
 
                 # 输出结果
                 logger.info(f"RSI-14 for {symbol}: {rsi_14:.2f}")
                 logger.info(f"RSI-6 for {symbol}: {rsi_6:.2f}")
+                logger.info(f"Latest price for {symbol}: ${latest_price:,.2f}")
                 
         except Exception as e:
             logger.error(f"Error processing {symbol}: {e}")

--- a/rsi4h.py
+++ b/rsi4h.py
@@ -128,10 +128,18 @@ def main() -> None:
             if rsi14_series is None or rsi6_series is None:
                 results[symbol] = {"rsi_14": None, "rsi_6": None, "error": True}
             else:
-                rsi14 = rsi14_series.iloc[-1]
-                rsi6 = rsi6_series.iloc[-1]
-                results[symbol] = {"rsi_14": rsi14, "rsi_6": rsi6, "error": False}
-                print(f"{symbol}: RSI-14={rsi14:.2f}, RSI-6={rsi6:.2f}")
+                rsi14 = float(rsi14_series.iloc[-1])
+                rsi6 = float(rsi6_series.iloc[-1])
+                latest_price = float(closes.iloc[-1])
+                results[symbol] = {
+                    "rsi_14": rsi14,
+                    "rsi_6": rsi6,
+                    "price": latest_price,
+                    "error": False,
+                }
+                print(
+                    f"{symbol}: RSI-14={rsi14:.2f}, RSI-6={rsi6:.2f}, price=${latest_price:,.2f}"
+                )
 
         if idx < total:
             time.sleep(Config.API_CALL_DELAY)

--- a/test_markdown.py
+++ b/test_markdown.py
@@ -17,12 +17,12 @@ def test_markdown_formatting():
     print("=" * 60)
     
     # 模拟极端RSI数据
-    test_extreme_rsi = {
-        "BTC (RSI-14)": "超买: 72.50",
-        "ETH (RSI-6)": "超卖: 28.30",
-        "SOL (RSI-14)": "超买: 68.20",
-        "APT (RSI-6)": "超卖: 25.80"
-    }
+    test_extreme_rsi = [
+        {"symbol": "BTC", "indicator": "RSI-14", "signal": "超买", "rsi_value": 72.50, "price": 63123.45},
+        {"symbol": "ETH", "indicator": "RSI-6", "signal": "超卖", "rsi_value": 28.30, "price": 3123.11},
+        {"symbol": "SOL", "indicator": "RSI-14", "signal": "超买", "rsi_value": 68.20, "price": 154.92},
+        {"symbol": "APT", "indicator": "RSI-6", "signal": "超卖", "rsi_value": 25.80, "price": 9.82},
+    ]
     
     # 格式化消息
     title, content = format_rsi_message(test_extreme_rsi)


### PR DESCRIPTION
## Summary
- store the latest USD price with RSI values in both the daily and 4-hour collectors
- return structured extreme-RSI entries and include a price column in the rendered tables
- refresh helper scripts/tests to cover the new data format and price output

## Testing
- python quick_test.py

------
https://chatgpt.com/codex/tasks/task_e_68cafbd798108321b0d8ebd4e2409ac7