### PR TITLE
Add timeframe tags to RSI push titles

### DIFF
--- a/rsi1d.py
+++ b/rsi1d.py
@@ -298,7 +298,7 @@ def main():
         # 处理通知
         if extreme_rsi:
             # 使用新的Markdown格式化函数
-            title, content = format_rsi_message(extreme_rsi)
+            title, content = format_rsi_message(extreme_rsi, timeframe_tag="rsi1d")
             
             # 打印最终需要发送的消息
             print("\n" + "=" * 50)

--- a/rsi4h.py
+++ b/rsi4h.py
@@ -146,7 +146,7 @@ def main() -> None:
 
     extreme = analyze_extreme_rsi(results)
     if extreme:
-        title, content = format_rsi_message(extreme)
+        title, content = format_rsi_message(extreme, timeframe_tag="rsi4h")
         send_notification(title, content)
 
 

--- a/rsi_utils.py
+++ b/rsi_utils.py
@@ -110,8 +110,16 @@ def _format_price(value: Any) -> str:
     return "--"
 
 
-def format_rsi_message(extreme_rsi: Sequence[Dict[str, Any]]) -> Tuple[str, str]:
-    """Format extreme RSI readings into a rich Markdown message."""
+def format_rsi_message(
+    extreme_rsi: Sequence[Dict[str, Any]], timeframe_tag: Optional[str] = None
+) -> Tuple[str, str]:
+    """Format extreme RSI readings into a rich Markdown message.
+
+    Args:
+        extreme_rsi: Extreme RSI readings collected from calculations.
+        timeframe_tag: Optional label describing the timeframe (e.g. ``"rsi1d"``
+            or ``"rsi4h"``) to be prefixed to the notification title.
+    """
     if not extreme_rsi:
         return "", ""
 
@@ -125,7 +133,8 @@ def format_rsi_message(extreme_rsi: Sequence[Dict[str, Any]]) -> Tuple[str, str]
         elif signal == "超卖":
             oversold_items.append(entry)
 
-    title = f"RSI-{len(overbought_items)}个超买,{len(oversold_items)}个超卖信号"
+    base_title = f"RSI-{len(overbought_items)}个超买,{len(oversold_items)}个超卖信号"
+    title = f"{timeframe_tag} | {base_title}" if timeframe_tag else base_title
 
     content_lines: List[str] = [
         "## 📈 RSI技术指标分析",


### PR DESCRIPTION
## Summary
- allow callers to specify a timeframe label for formatted RSI notifications
- include rsi1d and rsi4h tags in their respective push notification titles

## Testing
- python -m compileall rsi1d.py rsi4h.py rsi_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d00b13a1dc8321b571f305df3439b2